### PR TITLE
add xmlns:android...

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.mbppower.camerapreview"
     version="0.0.8">
     <name>CameraPreview</name>


### PR DESCRIPTION
I needed to add this line so that visual studio 2015 could install this plugin.  Otherwise, VS2015 kept rejecting the install.  Whenever you view plugin.xml on the VS2015 editor, it would show errors on every "android:name" line.
