### PR TITLE
bugfix: no callback when App can't access Photos. Also error message.

### DIFF
--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -274,8 +274,8 @@
                 } else {
                      previewPicturePath = [assetURL absoluteString];
                      NSLog(@"previewPicturePath: %@", previewPicturePath);
-                     dispatch_group_leave(group);
                 }
+                dispatch_group_leave(group);
             }];
                 
             //task 2


### PR DESCRIPTION
mbppower—

First of all, thanks for making and publishing this excellent plugin.

I've found a bug in your plugin and have some fixes for it in this pull request. The bug is: When your app doesn't have permission to access Photos, the user will tap the camera preview image, she will hear the camera snapping sound, but the callback is never called so the app is now stuck.

My first commit fixes this bug--`dispatch_group_leave()` was not being called when the error happens. This commit is one line and doesn't change the intention of the code, so I think you can use it as-is.

The second commit returns the error to Javascript so it can detect the condition and report it to the user. It's an API change and you may or may not agree with how the error condition is signaled. Take it if you like.

—Winston
Steve and Kate's Camp