### PR TITLE
Add a way to display the camera preview above all elements with transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Show camera preview popup on top of the HTML.<br/>
   <li>Send the preview box to back of the HTML content.</li>
   <li>Set a custom position for the camera preview box.</li>
   <li>Set a custom size for the preview box.</li>
+  <li>Set a custom alpha for the preview box.</li>
   <li>Maintain HTML interactivity.</li>
 </ul>
 
@@ -40,9 +41,9 @@ cordova plugin add https://github.com/mbppower/CordovaCameraPreview.git
 style="background-color='transparent'"
 ```
 </info>
-  
+
 Javascript:
-  
+
 ```
 var tapEnabled = true; //enable tap take picture
 var dragEnabled = true; //enable preview box drag across the screen
@@ -60,7 +61,7 @@ cordova.plugins.camerapreview.stopCamera();
 
 <b>takePicture(size)</b><br/>
 <info>Take the picture, the parameter size is optional</info><br/>
- 
+
 ```
 cordova.plugins.camerapreview.takePicture({maxWidth:640, maxHeight:640});
 ```
@@ -68,7 +69,7 @@ cordova.plugins.camerapreview.takePicture({maxWidth:640, maxHeight:640});
 
 <b>setOnPictureTakenHandler(callback)</b><br/>
 <info>Register a callback function that receives the original picture and the image captured from the preview box.</info><br/>
-  
+
 ```
 cordova.plugins.camerapreview.setOnPictureTakenHandler(function(result){
 	document.getElementById('originalPicture').src = result[0];//originalPicturePath;
@@ -109,8 +110,3 @@ Please see the <a href="https://github.com/mbppower/CordovaCameraPreviewApp">Cor
 <p><b>Android Screenshots:</b></p>
 <p><img src="https://raw.githubusercontent.com/mbppower/CordovaCameraPreview/master/docs/img/android-1.png"/></p>
 <p><img src="https://raw.githubusercontent.com/mbppower/CordovaCameraPreview/master/docs/img/android-2.png"/></p>
-
-
-
-
-

--- a/src/android/com/mbppower/CameraPreview.java
+++ b/src/android/com/mbppower/CameraPreview.java
@@ -62,7 +62,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 	    else if (switchCameraAction.equals(action)){
 		    return switchCamera(args, callbackContext);
 	    }
-    	
+
     	return false;
     }
 
@@ -109,6 +109,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 					}
 					else{
 						//set camera back to front
+						containerView.setAlpha(Float.parseFloat(args.getString(8)));
 						containerView.bringToFront();
 					}
 
@@ -162,7 +163,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
       return true;
     }
 
-    Camera.Parameters params = camera.getParameters();    
+    Camera.Parameters params = camera.getParameters();
 
     try {
       String effect = args.getString(0);

--- a/src/ios/CameraPreview.m
+++ b/src/ios/CameraPreview.m
@@ -9,312 +9,312 @@
 
 - (void) startCamera:(CDVInvokedUrlCommand*)command {
 
-    CDVPluginResult *pluginResult;
+        CDVPluginResult *pluginResult;
 
-    if (self.sessionManager != nil) {
-      pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera already started!"];
-      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-      return;
-    }
-
-    if (command.arguments.count > 3) {
-        CGFloat x = (CGFloat)[command.arguments[0] floatValue] + self.webView.frame.origin.x;
-        CGFloat y = (CGFloat)[command.arguments[1] floatValue] + self.webView.frame.origin.y;
-        CGFloat width = (CGFloat)[command.arguments[2] floatValue];
-        CGFloat height = (CGFloat)[command.arguments[3] floatValue];
-        NSString *defaultCamera = command.arguments[4];
-        BOOL tapToTakePicture = (BOOL)[command.arguments[5] boolValue];
-        BOOL dragEnabled = (BOOL)[command.arguments[6] boolValue];
-        BOOL toBack = (BOOL)[command.arguments[7] boolValue];
-        // Create the session manager
-        self.sessionManager = [[CameraSessionManager alloc] init];
-
-        //render controller setup
-        self.cameraRenderController = [[CameraRenderController alloc] init];
-        self.cameraRenderController.dragEnabled = dragEnabled;
-        self.cameraRenderController.tapToTakePicture = tapToTakePicture;
-        self.cameraRenderController.sessionManager = self.sessionManager;
-        self.cameraRenderController.view.frame = CGRectMake(x, y, width, height);
-        self.cameraRenderController.delegate = self;
-
-        [self.viewController addChildViewController:self.cameraRenderController];
-        //display the camera bellow the webview
-        if (toBack) {
-            //make transparent
-            self.webView.opaque = NO;
-            self.webView.backgroundColor = [UIColor clearColor];
-            [self.viewController.view insertSubview:self.cameraRenderController.view atIndex:0];
-        }
-        else{
-          self.cameraRenderController.view.alpha = (CGFloat)[command.arguments[8] floatValue];
-
-             [self.viewController.view addSubview:self.cameraRenderController.view];
+        if (self.sessionManager != nil) {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera already started!"];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+                return;
         }
 
-        // Setup session
-        self.sessionManager.delegate = self.cameraRenderController;
-        [self.sessionManager setupSession:defaultCamera];
+        if (command.arguments.count > 3) {
+                CGFloat x = (CGFloat)[command.arguments[0] floatValue] + self.webView.frame.origin.x;
+                CGFloat y = (CGFloat)[command.arguments[1] floatValue] + self.webView.frame.origin.y;
+                CGFloat width = (CGFloat)[command.arguments[2] floatValue];
+                CGFloat height = (CGFloat)[command.arguments[3] floatValue];
+                NSString *defaultCamera = command.arguments[4];
+                BOOL tapToTakePicture = (BOOL)[command.arguments[5] boolValue];
+                BOOL dragEnabled = (BOOL)[command.arguments[6] boolValue];
+                BOOL toBack = (BOOL)[command.arguments[7] boolValue];
+                // Create the session manager
+                self.sessionManager = [[CameraSessionManager alloc] init];
 
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid number of parameters"];
-    }
+                //render controller setup
+                self.cameraRenderController = [[CameraRenderController alloc] init];
+                self.cameraRenderController.dragEnabled = dragEnabled;
+                self.cameraRenderController.tapToTakePicture = tapToTakePicture;
+                self.cameraRenderController.sessionManager = self.sessionManager;
+                self.cameraRenderController.view.frame = CGRectMake(x, y, width, height);
+                self.cameraRenderController.delegate = self;
 
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+                [self.viewController addChildViewController:self.cameraRenderController];
+                //display the camera bellow the webview
+                if (toBack) {
+                        //make transparent
+                        self.webView.opaque = NO;
+                        self.webView.backgroundColor = [UIColor clearColor];
+                        [self.viewController.view insertSubview:self.cameraRenderController.view atIndex:0];
+                }
+                else{
+                        self.cameraRenderController.view.alpha = (CGFloat)[command.arguments[8] floatValue];
+
+                        [self.viewController.view addSubview:self.cameraRenderController.view];
+                }
+
+                // Setup session
+                self.sessionManager.delegate = self.cameraRenderController;
+                [self.sessionManager setupSession:defaultCamera];
+
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        } else {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid number of parameters"];
+        }
+
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) stopCamera:(CDVInvokedUrlCommand*)command {
-    NSLog(@"stopCamera");
-    CDVPluginResult *pluginResult;
+        NSLog(@"stopCamera");
+        CDVPluginResult *pluginResult;
 
-    if(self.sessionManager != nil){
-        [self.cameraRenderController.view removeFromSuperview];
-        [self.cameraRenderController removeFromParentViewController];
-        self.cameraRenderController = nil;
+        if(self.sessionManager != nil) {
+                [self.cameraRenderController.view removeFromSuperview];
+                [self.cameraRenderController removeFromParentViewController];
+                self.cameraRenderController = nil;
 
-        [self.sessionManager.session stopRunning];
-        self.sessionManager = nil;
+                [self.sessionManager.session stopRunning];
+                self.sessionManager = nil;
 
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    }
-    else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
-    }
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        }
+        else {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+        }
 
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) hideCamera:(CDVInvokedUrlCommand*)command {
-    NSLog(@"hideCamera");
-    CDVPluginResult *pluginResult;
+        NSLog(@"hideCamera");
+        CDVPluginResult *pluginResult;
 
-    if (self.cameraRenderController != nil) {
-        [self.cameraRenderController.view setHidden:YES];
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
-    }
+        if (self.cameraRenderController != nil) {
+                [self.cameraRenderController.view setHidden:YES];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        } else {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+        }
 
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) showCamera:(CDVInvokedUrlCommand*)command {
-    NSLog(@"showCamera");
-    CDVPluginResult *pluginResult;
+        NSLog(@"showCamera");
+        CDVPluginResult *pluginResult;
 
-    if (self.cameraRenderController != nil) {
-        [self.cameraRenderController.view setHidden:NO];
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
-    }
+        if (self.cameraRenderController != nil) {
+                [self.cameraRenderController.view setHidden:NO];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        } else {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+        }
 
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) switchCamera:(CDVInvokedUrlCommand*)command {
-    NSLog(@"switchCamera");
-    CDVPluginResult *pluginResult;
+        NSLog(@"switchCamera");
+        CDVPluginResult *pluginResult;
 
-    if (self.sessionManager != nil) {
-        [self.sessionManager switchCamera];
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
-    }
+        if (self.sessionManager != nil) {
+                [self.sessionManager switchCamera];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        } else {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+        }
 
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) takePicture:(CDVInvokedUrlCommand*)command {
-    NSLog(@"takePicture");
-    CDVPluginResult *pluginResult;
+        NSLog(@"takePicture");
+        CDVPluginResult *pluginResult;
 
-    if (self.cameraRenderController != NULL) {
-		CGFloat maxW = (CGFloat)[command.arguments[0] floatValue];
-    	CGFloat maxH = (CGFloat)[command.arguments[1] floatValue];
-        [self invokeTakePicture:maxW withHeight:maxH];
-    } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }
+        if (self.cameraRenderController != NULL) {
+                CGFloat maxW = (CGFloat)[command.arguments[0] floatValue];
+                CGFloat maxH = (CGFloat)[command.arguments[1] floatValue];
+                [self invokeTakePicture:maxW withHeight:maxH];
+        } else {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera not started"];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
 }
 
 -(void) setOnPictureTakenHandler:(CDVInvokedUrlCommand*)command {
-    NSLog(@"setOnPictureTakenHandler");
-    self.onPictureTakenHandlerId = command.callbackId;
+        NSLog(@"setOnPictureTakenHandler");
+        self.onPictureTakenHandlerId = command.callbackId;
 }
 
 -(void) setColorEffect:(CDVInvokedUrlCommand*)command {
-    NSLog(@"setColorEffect");
-    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    NSString *filterName = command.arguments[0];
+        NSLog(@"setColorEffect");
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        NSString *filterName = command.arguments[0];
 
-    if ([filterName isEqual: @"none"]) {
-        dispatch_async(self.sessionManager.sessionQueue, ^{
-            [self.sessionManager setCiFilter:nil];
-        });
-    } else if ([filterName isEqual: @"mono"]) {
-        dispatch_async(self.sessionManager.sessionQueue, ^{
-            CIFilter *filter = [CIFilter filterWithName:@"CIColorMonochrome"];
-            [filter setDefaults];
-            [self.sessionManager setCiFilter:filter];
-        });
-    } else if ([filterName isEqual: @"negative"]) {
-        dispatch_async(self.sessionManager.sessionQueue, ^{
-            CIFilter *filter = [CIFilter filterWithName:@"CIColorInvert"];
-            [filter setDefaults];
-            [self.sessionManager setCiFilter:filter];
-        });
-    } else if ([filterName isEqual: @"posterize"]) {
-        dispatch_async(self.sessionManager.sessionQueue, ^{
-            CIFilter *filter = [CIFilter filterWithName:@"CIColorPosterize"];
-            [filter setDefaults];
-            [self.sessionManager setCiFilter:filter];
-        });
-    } else if ([filterName isEqual: @"sepia"]) {
-        dispatch_async(self.sessionManager.sessionQueue, ^{
-            CIFilter *filter = [CIFilter filterWithName:@"CISepiaTone"];
-            [filter setDefaults];
-            [self.sessionManager setCiFilter:filter];
-        });
-    } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Filter not found"];
-    }
+        if ([filterName isEqual: @"none"]) {
+                dispatch_async(self.sessionManager.sessionQueue, ^{
+                        [self.sessionManager setCiFilter:nil];
+                });
+        } else if ([filterName isEqual: @"mono"]) {
+                dispatch_async(self.sessionManager.sessionQueue, ^{
+                        CIFilter *filter = [CIFilter filterWithName:@"CIColorMonochrome"];
+                        [filter setDefaults];
+                        [self.sessionManager setCiFilter:filter];
+                });
+        } else if ([filterName isEqual: @"negative"]) {
+                dispatch_async(self.sessionManager.sessionQueue, ^{
+                        CIFilter *filter = [CIFilter filterWithName:@"CIColorInvert"];
+                        [filter setDefaults];
+                        [self.sessionManager setCiFilter:filter];
+                });
+        } else if ([filterName isEqual: @"posterize"]) {
+                dispatch_async(self.sessionManager.sessionQueue, ^{
+                        CIFilter *filter = [CIFilter filterWithName:@"CIColorPosterize"];
+                        [filter setDefaults];
+                        [self.sessionManager setCiFilter:filter];
+                });
+        } else if ([filterName isEqual: @"sepia"]) {
+                dispatch_async(self.sessionManager.sessionQueue, ^{
+                        CIFilter *filter = [CIFilter filterWithName:@"CISepiaTone"];
+                        [filter setDefaults];
+                        [self.sessionManager setCiFilter:filter];
+                });
+        } else {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Filter not found"];
+        }
 
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 - (void) invokeTakePicture {
-    [self invokeTakePicture:0.0 withHeight:0.0];
+        [self invokeTakePicture:0.0 withHeight:0.0];
 }
 - (void) invokeTakePicture:(CGFloat) maxWidth withHeight:(CGFloat) maxHeight {
-    AVCaptureConnection *connection = [self.sessionManager.stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
-    [self.sessionManager.stillImageOutput captureStillImageAsynchronouslyFromConnection:connection completionHandler:^(CMSampleBufferRef sampleBuffer, NSError *error) {
+        AVCaptureConnection *connection = [self.sessionManager.stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
+        [self.sessionManager.stillImageOutput captureStillImageAsynchronouslyFromConnection:connection completionHandler:^(CMSampleBufferRef sampleBuffer, NSError *error) {
 
-        NSLog(@"Done creating still image");
+                 NSLog(@"Done creating still image");
 
-        if (error) {
-            NSLog(@"%@", error);
-        } else {
-            [self.cameraRenderController.renderLock lock];
-            CIImage *previewCImage = self.cameraRenderController.latestFrame;
-            CGImageRef previewImage = [self.cameraRenderController.ciContext createCGImage:previewCImage fromRect:previewCImage.extent];
-            [self.cameraRenderController.renderLock unlock];
+                 if (error) {
+                         NSLog(@"%@", error);
+                 } else {
+                         [self.cameraRenderController.renderLock lock];
+                         CIImage *previewCImage = self.cameraRenderController.latestFrame;
+                         CGImageRef previewImage = [self.cameraRenderController.ciContext createCGImage:previewCImage fromRect:previewCImage.extent];
+                         [self.cameraRenderController.renderLock unlock];
 
-            NSData *imageData = [AVCaptureStillImageOutput jpegStillImageNSDataRepresentation:sampleBuffer];
-            UIImage *capturedImage  = [[UIImage alloc] initWithData:imageData];
+                         NSData *imageData = [AVCaptureStillImageOutput jpegStillImageNSDataRepresentation:sampleBuffer];
+                         UIImage *capturedImage  = [[UIImage alloc] initWithData:imageData];
 
-            CIImage *capturedCImage;
-			//image resize
+                         CIImage *capturedCImage;
+                         //image resize
 
-			if(maxWidth > 0 && maxHeight > 0){
-				CGFloat scaleHeight = maxWidth/capturedImage.size.height;
-				CGFloat scaleWidth = maxHeight/capturedImage.size.width;
-				CGFloat scale = scaleHeight > scaleWidth ? scaleWidth : scaleHeight;
+                         if(maxWidth > 0 && maxHeight > 0) {
+                                 CGFloat scaleHeight = maxWidth/capturedImage.size.height;
+                                 CGFloat scaleWidth = maxHeight/capturedImage.size.width;
+                                 CGFloat scale = scaleHeight > scaleWidth ? scaleWidth : scaleHeight;
 
-				CIFilter *resizeFilter = [CIFilter filterWithName:@"CILanczosScaleTransform"];
-				[resizeFilter setValue:[[CIImage alloc] initWithCGImage:[capturedImage CGImage]] forKey:kCIInputImageKey];
-				[resizeFilter setValue:[NSNumber numberWithFloat:1.0f] forKey:@"inputAspectRatio"];
-				[resizeFilter setValue:[NSNumber numberWithFloat:scale] forKey:@"inputScale"];
-				capturedCImage = [resizeFilter outputImage];
-			}
-            else{
-                capturedCImage = [[CIImage alloc] initWithCGImage:[capturedImage CGImage]];
-            }
+                                 CIFilter *resizeFilter = [CIFilter filterWithName:@"CILanczosScaleTransform"];
+                                 [resizeFilter setValue:[[CIImage alloc] initWithCGImage:[capturedImage CGImage]] forKey:kCIInputImageKey];
+                                 [resizeFilter setValue:[NSNumber numberWithFloat:1.0f] forKey:@"inputAspectRatio"];
+                                 [resizeFilter setValue:[NSNumber numberWithFloat:scale] forKey:@"inputScale"];
+                                 capturedCImage = [resizeFilter outputImage];
+                         }
+                         else{
+                                 capturedCImage = [[CIImage alloc] initWithCGImage:[capturedImage CGImage]];
+                         }
 
-			CIImage *imageToFilter;
-			CIImage *finalCImage;
+                         CIImage *imageToFilter;
+                         CIImage *finalCImage;
 
-            //fix front mirroring
-            if (self.sessionManager.defaultCamera == AVCaptureDevicePositionFront) {
-               CGAffineTransform matrix = CGAffineTransformTranslate(CGAffineTransformMakeScale(1, -1), 0, capturedCImage.extent.size.height);
-               imageToFilter = [capturedCImage imageByApplyingTransform:matrix];
-            } else {
-               imageToFilter = capturedCImage;
-            }
+                         //fix front mirroring
+                         if (self.sessionManager.defaultCamera == AVCaptureDevicePositionFront) {
+                                 CGAffineTransform matrix = CGAffineTransformTranslate(CGAffineTransformMakeScale(1, -1), 0, capturedCImage.extent.size.height);
+                                 imageToFilter = [capturedCImage imageByApplyingTransform:matrix];
+                         } else {
+                                 imageToFilter = capturedCImage;
+                         }
 
-            CIFilter *filter = [self.sessionManager ciFilter];
-            if (filter != nil) {
-                [self.sessionManager.filterLock lock];
-                [filter setValue:imageToFilter forKey:kCIInputImageKey];
-                finalCImage = [filter outputImage];
-                [self.sessionManager.filterLock unlock];
-            } else {
-                finalCImage = imageToFilter;
-            }
+                         CIFilter *filter = [self.sessionManager ciFilter];
+                         if (filter != nil) {
+                                 [self.sessionManager.filterLock lock];
+                                 [filter setValue:imageToFilter forKey:kCIInputImageKey];
+                                 finalCImage = [filter outputImage];
+                                 [self.sessionManager.filterLock unlock];
+                         } else {
+                                 finalCImage = imageToFilter;
+                         }
 
-            CGImageRef finalImage = [self.cameraRenderController.ciContext createCGImage:finalCImage fromRect:finalCImage.extent];
+                         CGImageRef finalImage = [self.cameraRenderController.ciContext createCGImage:finalCImage fromRect:finalCImage.extent];
 
-            ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
+                         ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
 
-            dispatch_group_t group = dispatch_group_create();
+                         dispatch_group_t group = dispatch_group_create();
 
-            __block NSString *originalPicturePath;
-            __block NSString *previewPicturePath;
-            __block NSError *photosAlbumError;
+                         __block NSString *originalPicturePath;
+                         __block NSString *previewPicturePath;
+                         __block NSError *photosAlbumError;
 
-            ALAssetOrientation orientation;
-            switch ([[UIApplication sharedApplication] statusBarOrientation]) {
-                case UIDeviceOrientationPortraitUpsideDown:
-                    orientation = ALAssetOrientationLeft;
-                    break;
-                case UIDeviceOrientationLandscapeLeft:
-                    orientation = ALAssetOrientationUp;
-                    break;
-                case UIDeviceOrientationLandscapeRight:
-                    orientation = ALAssetOrientationDown;
-                    break;
-                case UIDeviceOrientationPortrait:
-                default:
-                    orientation = ALAssetOrientationRight;
-            }
+                         ALAssetOrientation orientation;
+                         switch ([[UIApplication sharedApplication] statusBarOrientation]) {
+                         case UIDeviceOrientationPortraitUpsideDown:
+                                 orientation = ALAssetOrientationLeft;
+                                 break;
+                         case UIDeviceOrientationLandscapeLeft:
+                                 orientation = ALAssetOrientationUp;
+                                 break;
+                         case UIDeviceOrientationLandscapeRight:
+                                 orientation = ALAssetOrientationDown;
+                                 break;
+                         case UIDeviceOrientationPortrait:
+                         default:
+                                 orientation = ALAssetOrientationRight;
+                         }
 
-            // task 1
-            dispatch_group_enter(group);
-            [library writeImageToSavedPhotosAlbum:previewImage orientation:ALAssetOrientationUp completionBlock:^(NSURL *assetURL, NSError *error) {
-                if (error) {
-                    NSLog(@"FAILED to save Preview picture.");
-                    photosAlbumError = error;
-                } else {
-                     previewPicturePath = [assetURL absoluteString];
-                     NSLog(@"previewPicturePath: %@", previewPicturePath);
-                }
-                dispatch_group_leave(group);
-            }];
+                         // task 1
+                         dispatch_group_enter(group);
+                         [library writeImageToSavedPhotosAlbum:previewImage orientation:ALAssetOrientationUp completionBlock:^(NSURL *assetURL, NSError *error) {
+                                  if (error) {
+                                          NSLog(@"FAILED to save Preview picture.");
+                                          photosAlbumError = error;
+                                  } else {
+                                          previewPicturePath = [assetURL absoluteString];
+                                          NSLog(@"previewPicturePath: %@", previewPicturePath);
+                                  }
+                                  dispatch_group_leave(group);
+                          }];
 
-            //task 2
-            dispatch_group_enter(group);
-            [library writeImageToSavedPhotosAlbum:finalImage orientation:orientation completionBlock:^(NSURL *assetURL, NSError *error) {
-                if (error) {
-                    NSLog(@"FAILED to save Original picture.");
-                    photosAlbumError = error;
-                } else {
-                    originalPicturePath = [assetURL absoluteString];
-                    NSLog(@"originalPicturePath: %@", originalPicturePath);
-                }
-                dispatch_group_leave(group);
-            }];
+                         //task 2
+                         dispatch_group_enter(group);
+                         [library writeImageToSavedPhotosAlbum:finalImage orientation:orientation completionBlock:^(NSURL *assetURL, NSError *error) {
+                                  if (error) {
+                                          NSLog(@"FAILED to save Original picture.");
+                                          photosAlbumError = error;
+                                  } else {
+                                          originalPicturePath = [assetURL absoluteString];
+                                          NSLog(@"originalPicturePath: %@", originalPicturePath);
+                                  }
+                                  dispatch_group_leave(group);
+                          }];
 
-            dispatch_group_notify(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-                NSMutableArray *params = [[NSMutableArray alloc] init];
-                if (photosAlbumError) {
-                    // Error returns just one element in the returned array
-                    NSString * remedy = @"";
-                    if (-3311 == [photosAlbumError code]) {
-                        remedy = @"Go to Settings > CodeStudio and allow access to Photos";
-                    }
-                    [params addObject:[NSString stringWithFormat:@"CameraPreview: %@ - %@ — %@", [photosAlbumError localizedDescription], [photosAlbumError localizedFailureReason], remedy]];
-                } else {
-                    // Success returns two elements in the returned array
-                    [params addObject:originalPicturePath];
-                    [params addObject:previewPicturePath];
-                }
+                         dispatch_group_notify(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+                                NSMutableArray *params = [[NSMutableArray alloc] init];
+                                if (photosAlbumError) {
+                                        // Error returns just one element in the returned array
+                                        NSString * remedy = @"";
+                                        if (-3311 == [photosAlbumError code]) {
+                                                remedy = @"Go to Settings > CodeStudio and allow access to Photos";
+                                        }
+                                        [params addObject:[NSString stringWithFormat:@"CameraPreview: %@ - %@ — %@", [photosAlbumError localizedDescription], [photosAlbumError localizedFailureReason], remedy]];
+                                } else {
+                                        // Success returns two elements in the returned array
+                                        [params addObject:originalPicturePath];
+                                        [params addObject:previewPicturePath];
+                                }
 
-                CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:params];
-                [pluginResult setKeepCallbackAsBool:true];
-                [self.commandDelegate sendPluginResult:pluginResult callbackId:self.onPictureTakenHandlerId];
-            });
-        }
-    }];
+                                CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:params];
+                                [pluginResult setKeepCallbackAsBool:true];
+                                [self.commandDelegate sendPluginResult:pluginResult callbackId:self.onPictureTakenHandlerId];
+                        });
+                 }
+         }];
 }
 @end

--- a/src/ios/CameraRenderController.h
+++ b/src/ios/CameraRenderController.h
@@ -14,10 +14,10 @@
 @end;
 
 @interface CameraRenderController : UIViewController <AVCaptureVideoDataOutputSampleBufferDelegate> {
-    GLuint _renderBuffer;
-    CVOpenGLESTextureCacheRef _videoTextureCache;
-    CVOpenGLESTextureRef _lumaTexture;
-    
+        GLuint _renderBuffer;
+        CVOpenGLESTextureCacheRef _videoTextureCache;
+        CVOpenGLESTextureRef _lumaTexture;
+
 }
 
 @property (nonatomic) GLKView *view;

--- a/src/ios/CameraRenderController.m
+++ b/src/ios/CameraRenderController.m
@@ -10,219 +10,219 @@
 
 
 - (CameraRenderController *)init {
-    if (self = [super init]) {
-        self.renderLock = [[NSLock alloc] init];
-    }
-    return self;
+        if (self = [super init]) {
+                self.renderLock = [[NSLock alloc] init];
+        }
+        return self;
 }
 
 - (void)loadView {
-    GLKView *glkView = [[GLKView alloc] init];
-    [glkView setBackgroundColor:[UIColor blackColor]];
-    [self setView:glkView];
+        GLKView *glkView = [[GLKView alloc] init];
+        [glkView setBackgroundColor:[UIColor blackColor]];
+        [self setView:glkView];
 }
 
 - (void)viewDidLoad
 {
-    [super viewDidLoad]; 
+        [super viewDidLoad];
 
-    self.context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
+        self.context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
 
-    if (!self.context) {
-        NSLog(@"Failed to create ES context");
-    }
-    
-    CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL, self.context, NULL, &_videoTextureCache);
-    if (err) {
-        NSLog(@"Error at CVOpenGLESTextureCacheCreate %d", err);
-        return;
-    }
-    
-    GLKView *view = (GLKView *)self.view;
-    view.context = self.context;
-    view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
-    view.contentMode = UIViewContentModeScaleToFill;
-    
-    glGenRenderbuffers(1, &_renderBuffer);
-    glBindRenderbuffer(GL_RENDERBUFFER, _renderBuffer);
-    
-    self.ciContext = [CIContext contextWithEAGLContext:self.context]; 
-    
-    if (self.dragEnabled) {
-        //add drag action listener
-        NSLog(@"Enabling view dragging");
-        UIPanGestureRecognizer *drag = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
-        [self.view addGestureRecognizer:drag];
-    }
+        if (!self.context) {
+                NSLog(@"Failed to create ES context");
+        }
 
-    if (self.tapToTakePicture) {
-        //tap to take picture
-        UITapGestureRecognizer *takePictureTap =
-        [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTakePictureTap:)];
-        [self.view addGestureRecognizer:takePictureTap];
-    }
+        CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL, self.context, NULL, &_videoTextureCache);
+        if (err) {
+                NSLog(@"Error at CVOpenGLESTextureCacheCreate %d", err);
+                return;
+        }
 
-    self.view.userInteractionEnabled = self.dragEnabled || self.tapToTakePicture;
+        GLKView *view = (GLKView *)self.view;
+        view.context = self.context;
+        view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
+        view.contentMode = UIViewContentModeScaleToFill;
+
+        glGenRenderbuffers(1, &_renderBuffer);
+        glBindRenderbuffer(GL_RENDERBUFFER, _renderBuffer);
+
+        self.ciContext = [CIContext contextWithEAGLContext:self.context];
+
+        if (self.dragEnabled) {
+                //add drag action listener
+                NSLog(@"Enabling view dragging");
+                UIPanGestureRecognizer *drag = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
+                [self.view addGestureRecognizer:drag];
+        }
+
+        if (self.tapToTakePicture) {
+                //tap to take picture
+                UITapGestureRecognizer *takePictureTap =
+                        [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTakePictureTap:)];
+                [self.view addGestureRecognizer:takePictureTap];
+        }
+
+        self.view.userInteractionEnabled = self.dragEnabled || self.tapToTakePicture;
 }
 
 - (void) viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
+        [super viewWillAppear:animated];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self 
-        selector:@selector(appplicationIsActive:) 
-        name:UIApplicationDidBecomeActiveNotification 
-        object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+         selector:@selector(appplicationIsActive:)
+         name:UIApplicationDidBecomeActiveNotification
+         object:nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self 
-        selector:@selector(applicationEnteredForeground:) 
-        name:UIApplicationWillEnterForegroundNotification
-        object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+         selector:@selector(applicationEnteredForeground:)
+         name:UIApplicationWillEnterForegroundNotification
+         object:nil];
 
-    dispatch_async(self.sessionManager.sessionQueue, ^{
-      NSLog(@"Starting session");
-      [self.sessionManager.session startRunning];
-    });
+        dispatch_async(self.sessionManager.sessionQueue, ^{
+                NSLog(@"Starting session");
+                [self.sessionManager.session startRunning];
+        });
 }
 
 - (void) viewWillDisappear:(BOOL)animated {
-    [super viewWillDisappear:animated];
+        [super viewWillDisappear:animated];
 
-    [[NSNotificationCenter defaultCenter] removeObserver:self
-        name:UIApplicationDidBecomeActiveNotification
-        object:nil];
+        [[NSNotificationCenter defaultCenter] removeObserver:self
+         name:UIApplicationDidBecomeActiveNotification
+         object:nil];
 
-    [[NSNotificationCenter defaultCenter] removeObserver:self
-        name:UIApplicationWillEnterForegroundNotification
-        object:nil];
+        [[NSNotificationCenter defaultCenter] removeObserver:self
+         name:UIApplicationWillEnterForegroundNotification
+         object:nil];
 
-    dispatch_async(self.sessionManager.sessionQueue, ^{
-      NSLog(@"Stopping session");
-      [self.sessionManager.session stopRunning];
-    });
+        dispatch_async(self.sessionManager.sessionQueue, ^{
+                NSLog(@"Stopping session");
+                [self.sessionManager.session stopRunning];
+        });
 }
 
 - (void) handleTakePictureTap:(UITapGestureRecognizer*)recognizer {
-    NSLog(@"handleTakePictureTap");
-    [self.delegate invokeTakePicture];
+        NSLog(@"handleTakePictureTap");
+        [self.delegate invokeTakePicture];
 }
 
 - (IBAction)handlePan:(UIPanGestureRecognizer *)recognizer {
-    CGPoint translation = [recognizer translationInView:self.view];
-    recognizer.view.center = CGPointMake(recognizer.view.center.x + translation.x, 
-                                     recognizer.view.center.y + translation.y);
-    [recognizer setTranslation:CGPointMake(0, 0) inView:self.view];
+        CGPoint translation = [recognizer translationInView:self.view];
+        recognizer.view.center = CGPointMake(recognizer.view.center.x + translation.x,
+                                             recognizer.view.center.y + translation.y);
+        [recognizer setTranslation:CGPointMake(0, 0) inView:self.view];
 }
 
 - (void) appplicationIsActive:(NSNotification *)notification {
-    dispatch_async(self.sessionManager.sessionQueue, ^{
-      NSLog(@"Starting session");
-      [self.sessionManager.session startRunning];
-    });
+        dispatch_async(self.sessionManager.sessionQueue, ^{
+                NSLog(@"Starting session");
+                [self.sessionManager.session startRunning];
+        });
 }
 
 - (void) applicationEnteredForeground:(NSNotification *)notification {
-    dispatch_async(self.sessionManager.sessionQueue, ^{
-      NSLog(@"Stopping session");
-      [self.sessionManager.session stopRunning];
-    });
+        dispatch_async(self.sessionManager.sessionQueue, ^{
+                NSLog(@"Stopping session");
+                [self.sessionManager.session stopRunning];
+        });
 }
 //TODO:Use TEXTURE_2D
 -(void)captureOutput:(AVCaptureOutput *)captureOutput didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection *)connection {
-    if ([self.renderLock tryLock]) {
-        CVPixelBufferRef pixelBuffer = (CVPixelBufferRef)CMSampleBufferGetImageBuffer(sampleBuffer);
-        CIImage *image = [CIImage imageWithCVPixelBuffer:pixelBuffer];
-        
-		
-        CGFloat scaleHeight = self.view.frame.size.height/image.extent.size.height;
-        CGFloat scaleWidth = self.view.frame.size.width/image.extent.size.width;
+        if ([self.renderLock tryLock]) {
+                CVPixelBufferRef pixelBuffer = (CVPixelBufferRef)CMSampleBufferGetImageBuffer(sampleBuffer);
+                CIImage *image = [CIImage imageWithCVPixelBuffer:pixelBuffer];
 
-        CGFloat scale, x, y;
-        if (scaleHeight < scaleWidth) {
-            scale = scaleWidth;
-            x = 0;
-            y = ((scale * image.extent.size.height) - self.view.frame.size.height ) / 2;
-        } else {
-            scale = scaleHeight;
-            x = ((scale * image.extent.size.width) - self.view.frame.size.width )/ 2;
-            y = 0;
+
+                CGFloat scaleHeight = self.view.frame.size.height/image.extent.size.height;
+                CGFloat scaleWidth = self.view.frame.size.width/image.extent.size.width;
+
+                CGFloat scale, x, y;
+                if (scaleHeight < scaleWidth) {
+                        scale = scaleWidth;
+                        x = 0;
+                        y = ((scale * image.extent.size.height) - self.view.frame.size.height ) / 2;
+                } else {
+                        scale = scaleHeight;
+                        x = ((scale * image.extent.size.width) - self.view.frame.size.width )/ 2;
+                        y = 0;
+                }
+
+                // scale - translate
+                CGAffineTransform xscale = CGAffineTransformMakeScale(scale, scale);
+                CGAffineTransform xlate = CGAffineTransformMakeTranslation(-x, -y);
+                CGAffineTransform xform =  CGAffineTransformConcat(xscale, xlate);
+
+                CIFilter *centerFilter = [CIFilter filterWithName:@"CIAffineTransform"  keysAndValues:
+                                          kCIInputImageKey, image,
+                                          kCIInputTransformKey, [NSValue valueWithBytes:&xform objCType:@encode(CGAffineTransform)],
+                                          nil];
+
+                CIImage *transformedImage = [centerFilter outputImage];
+
+                // crop
+                CIFilter *cropFilter = [CIFilter filterWithName:@"CICrop"];
+                CIVector *cropRect = [CIVector vectorWithX:0 Y:0 Z:self.view.frame.size.width W:self.view.frame.size.height];
+                [cropFilter setValue:transformedImage forKey:kCIInputImageKey];
+                [cropFilter setValue:cropRect forKey:@"inputRectangle"];
+                CIImage *croppedImage = [cropFilter outputImage];
+
+                CIFilter *filter = [self.sessionManager ciFilter];
+
+                CIImage *result;
+                if (filter != nil) {
+                        [self.sessionManager.filterLock lock];
+                        [filter setValue:croppedImage forKey:kCIInputImageKey];
+                        result = [filter outputImage];
+                        [self.sessionManager.filterLock unlock];
+                }
+                else {
+                        result = croppedImage;
+                }
+
+                //fix front mirroring
+                if (self.sessionManager.defaultCamera == AVCaptureDevicePositionFront) {
+                        CGAffineTransform matrix = CGAffineTransformTranslate(CGAffineTransformMakeScale(-1, 1), 0, result.extent.size.height);
+                        result = [result imageByApplyingTransform:matrix];
+                }
+
+                self.latestFrame = result;
+
+                CGFloat pointScale;
+                if ([[UIScreen mainScreen] respondsToSelector:@selector(nativeScale)]) {
+                        pointScale = [[UIScreen mainScreen] nativeScale];
+                } else {
+                        pointScale = [[UIScreen mainScreen] scale];
+                }
+                CGRect dest = CGRectMake(0, 0, self.view.frame.size.width*pointScale, self.view.frame.size.height*pointScale);
+
+                [self.ciContext drawImage:result inRect:dest fromRect:[result extent]];
+                [self.context presentRenderbuffer:GL_RENDERBUFFER];
+                [(GLKView *)(self.view)display];
+                [self.renderLock unlock];
         }
-
-        // scale - translate
-        CGAffineTransform xscale = CGAffineTransformMakeScale(scale, scale);
-        CGAffineTransform xlate = CGAffineTransformMakeTranslation(-x, -y);
-        CGAffineTransform xform =  CGAffineTransformConcat(xscale, xlate); 
-        
-        CIFilter *centerFilter = [CIFilter filterWithName:@"CIAffineTransform"  keysAndValues:
-                                  kCIInputImageKey, image,
-                                  kCIInputTransformKey, [NSValue valueWithBytes:&xform objCType:@encode(CGAffineTransform)],
-                                  nil];
-
-        CIImage *transformedImage = [centerFilter outputImage];
-        
-        // crop
-        CIFilter *cropFilter = [CIFilter filterWithName:@"CICrop"];
-        CIVector *cropRect = [CIVector vectorWithX:0 Y:0 Z:self.view.frame.size.width W:self.view.frame.size.height];
-        [cropFilter setValue:transformedImage forKey:kCIInputImageKey];
-        [cropFilter setValue:cropRect forKey:@"inputRectangle"];
-        CIImage *croppedImage = [cropFilter outputImage];
-        
-        CIFilter *filter = [self.sessionManager ciFilter];
-
-        CIImage *result;
-        if (filter != nil) {
-            [self.sessionManager.filterLock lock];
-            [filter setValue:croppedImage forKey:kCIInputImageKey];
-            result = [filter outputImage];
-            [self.sessionManager.filterLock unlock];
-        }
-		else {
-            result = croppedImage;
-        }
-
-        //fix front mirroring
-        if (self.sessionManager.defaultCamera == AVCaptureDevicePositionFront) {
-            CGAffineTransform matrix = CGAffineTransformTranslate(CGAffineTransformMakeScale(-1, 1), 0, result.extent.size.height);
-            result = [result imageByApplyingTransform:matrix];
-        }
-
-        self.latestFrame = result;
-
-        CGFloat pointScale;
-        if ([[UIScreen mainScreen] respondsToSelector:@selector(nativeScale)]) {
-            pointScale = [[UIScreen mainScreen] nativeScale];
-        } else {
-            pointScale = [[UIScreen mainScreen] scale];
-        }
-        CGRect dest = CGRectMake(0, 0, self.view.frame.size.width*pointScale, self.view.frame.size.height*pointScale);
-
-        [self.ciContext drawImage:result inRect:dest fromRect:[result extent]];
-        [self.context presentRenderbuffer:GL_RENDERBUFFER];
-        [(GLKView *)(self.view) display];
-        [self.renderLock unlock];
-    }
 }
 
 - (void)viewDidUnload
 {
-    [super viewDidUnload];
+        [super viewDidUnload];
 
-    if ([EAGLContext currentContext] == self.context) {
-        [EAGLContext setCurrentContext:nil];
-    }
-    self.context = nil;
+        if ([EAGLContext currentContext] == self.context) {
+                [EAGLContext setCurrentContext:nil];
+        }
+        self.context = nil;
 }
 
 - (void)didReceiveMemoryWarning
 {
-    [super didReceiveMemoryWarning];
-    // Release any cached data, images, etc. that aren't in use.
+        [super didReceiveMemoryWarning];
+        // Release any cached data, images, etc. that aren't in use.
 }
 
 - (BOOL)shouldAutorotate {
-    return YES;
+        return YES;
 }
 -(void) willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {
-    [self.sessionManager updateOrientation:[self.sessionManager getCurrentOrientation:toInterfaceOrientation]];
+        [self.sessionManager updateOrientation:[self.sessionManager getCurrentOrientation:toInterfaceOrientation]];
 }
 @end

--- a/src/ios/CameraSessionManager.m
+++ b/src/ios/CameraSessionManager.m
@@ -4,189 +4,189 @@
 
 - (CameraSessionManager *)init
 {
-    if (self = [super init]) {
-        // Create the AVCaptureSession
-        self.session = [[AVCaptureSession alloc] init];
-        self.sessionQueue = dispatch_queue_create("session queue", DISPATCH_QUEUE_SERIAL);
-        self.filterLock = [[NSLock alloc] init];
-        [self setCiFilter:nil];
-    }
-    return self;
+        if (self = [super init]) {
+                // Create the AVCaptureSession
+                self.session = [[AVCaptureSession alloc] init];
+                self.sessionQueue = dispatch_queue_create("session queue", DISPATCH_QUEUE_SERIAL);
+                self.filterLock = [[NSLock alloc] init];
+                [self setCiFilter:nil];
+        }
+        return self;
 }
 - (AVCaptureVideoOrientation) getCurrentOrientation/*:(UIInterfaceOrientation)toInterfaceOrientation*/
 {
-    return [self getCurrentOrientation: [[UIApplication sharedApplication] statusBarOrientation]];
+        return [self getCurrentOrientation: [[UIApplication sharedApplication] statusBarOrientation]];
 }
 - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation
 {
-    AVCaptureVideoOrientation orientation;
-    switch (toInterfaceOrientation) {
-        case UIInterfaceOrientationPortraitUpsideDown :
-            orientation = AVCaptureVideoOrientationPortraitUpsideDown;
-            break;
+        AVCaptureVideoOrientation orientation;
+        switch (toInterfaceOrientation) {
+        case UIInterfaceOrientationPortraitUpsideDown:
+                orientation = AVCaptureVideoOrientationPortraitUpsideDown;
+                break;
         case UIInterfaceOrientationLandscapeRight:
-            orientation = AVCaptureVideoOrientationLandscapeRight;
-            break;
+                orientation = AVCaptureVideoOrientationLandscapeRight;
+                break;
         case UIInterfaceOrientationLandscapeLeft:
-            orientation = AVCaptureVideoOrientationLandscapeLeft;
-            break;
+                orientation = AVCaptureVideoOrientationLandscapeLeft;
+                break;
         default:
         case UIInterfaceOrientationPortrait:
-            orientation = AVCaptureVideoOrientationPortrait;
-    }
-    return orientation;
+                orientation = AVCaptureVideoOrientationPortrait;
+        }
+        return orientation;
 }
 - (void) setupSession:(NSString *)defaultCamera
 {
-    // If this fails, video input will just stream blank frames
-    // and the user will be notified. User only has to accep once.
-    [self checkDeviceAuthorizationStatus];
+        // If this fails, video input will just stream blank frames
+        // and the user will be notified. User only has to accep once.
+        [self checkDeviceAuthorizationStatus];
 
-    dispatch_async(self.sessionQueue, ^{
-        NSError *error = nil;
+        dispatch_async(self.sessionQueue, ^{
+                NSError *error = nil;
 
-        NSLog(@"defaultCamera: %@", defaultCamera);
-        if ([defaultCamera isEqual: @"front"]) {
-            self.defaultCamera = AVCaptureDevicePositionFront;
-        } else {
-            self.defaultCamera = AVCaptureDevicePositionBack;
-        }
+                NSLog(@"defaultCamera: %@", defaultCamera);
+                if ([defaultCamera isEqual: @"front"]) {
+                        self.defaultCamera = AVCaptureDevicePositionFront;
+                } else {
+                        self.defaultCamera = AVCaptureDevicePositionBack;
+                }
 
-        AVCaptureDevice *videoDevice = [CameraSessionManager deviceWithMediaType:AVMediaTypeVideo preferringPosition:self.defaultCamera];        
+                AVCaptureDevice *videoDevice = [CameraSessionManager deviceWithMediaType:AVMediaTypeVideo preferringPosition:self.defaultCamera];
 
-        if ([videoDevice hasFlash] && [videoDevice isFlashModeSupported:AVCaptureFlashModeAuto]) {
-            if ([videoDevice lockForConfiguration:&error]) {
-                [videoDevice setFlashMode:AVCaptureFlashModeAuto];
-                [videoDevice unlockForConfiguration];
-            } else {
-                NSLog(@"%@", error);
-            }
-        }
+                if ([videoDevice hasFlash] && [videoDevice isFlashModeSupported:AVCaptureFlashModeAuto]) {
+                        if ([videoDevice lockForConfiguration:&error]) {
+                                [videoDevice setFlashMode:AVCaptureFlashModeAuto];
+                                [videoDevice unlockForConfiguration];
+                        } else {
+                                NSLog(@"%@", error);
+                        }
+                }
 
-        AVCaptureDeviceInput *videoDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:videoDevice error:&error];
+                AVCaptureDeviceInput *videoDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:videoDevice error:&error];
 
-        if (error) {
-            NSLog(@"%@", error);
-        }
+                if (error) {
+                        NSLog(@"%@", error);
+                }
 
-        if ([self.session canAddInput:videoDeviceInput]) {
-            [self.session addInput:videoDeviceInput];
-            self.videoDeviceInput = videoDeviceInput;
-        }
+                if ([self.session canAddInput:videoDeviceInput]) {
+                        [self.session addInput:videoDeviceInput];
+                        self.videoDeviceInput = videoDeviceInput;
+                }
 
-        AVCaptureStillImageOutput *stillImageOutput = [[AVCaptureStillImageOutput alloc] init];
-        if ([self.session canAddOutput:stillImageOutput]) {
-            [self.session addOutput:stillImageOutput];
-            [stillImageOutput setOutputSettings:@{AVVideoCodecKey : AVVideoCodecJPEG}];
-            self.stillImageOutput = stillImageOutput;
-        }
+                AVCaptureStillImageOutput *stillImageOutput = [[AVCaptureStillImageOutput alloc] init];
+                if ([self.session canAddOutput:stillImageOutput]) {
+                        [self.session addOutput:stillImageOutput];
+                        [stillImageOutput setOutputSettings:@{AVVideoCodecKey : AVVideoCodecJPEG}];
+                        self.stillImageOutput = stillImageOutput;
+                }
 
-        AVCaptureVideoDataOutput *dataOutput = [[AVCaptureVideoDataOutput alloc] init];
-        if ([self.session canAddOutput:dataOutput]) {
-            self.dataOutput = dataOutput;
-            [dataOutput setAlwaysDiscardsLateVideoFrames:YES];
-            [dataOutput setVideoSettings:[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:kCVPixelFormatType_32BGRA] forKey:(id)kCVPixelBufferPixelFormatTypeKey]];
+                AVCaptureVideoDataOutput *dataOutput = [[AVCaptureVideoDataOutput alloc] init];
+                if ([self.session canAddOutput:dataOutput]) {
+                        self.dataOutput = dataOutput;
+                        [dataOutput setAlwaysDiscardsLateVideoFrames:YES];
+                        [dataOutput setVideoSettings:[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:kCVPixelFormatType_32BGRA] forKey:(id)kCVPixelBufferPixelFormatTypeKey]];
 
-            [dataOutput setSampleBufferDelegate:self.delegate queue:self.sessionQueue];
+                        [dataOutput setSampleBufferDelegate:self.delegate queue:self.sessionQueue];
 
-            [self.session addOutput:dataOutput];
-        }
-        
-        [self updateOrientation:[self getCurrentOrientation]];
-    });
+                        [self.session addOutput:dataOutput];
+                }
+
+                [self updateOrientation:[self getCurrentOrientation]];
+        });
 }
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation
 {
-    AVCaptureConnection *captureConnection;
-    if (self.stillImageOutput != nil) {
-        captureConnection = [self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
-        if ([captureConnection isVideoOrientationSupported]) {
-            [captureConnection setVideoOrientation:orientation];
+        AVCaptureConnection *captureConnection;
+        if (self.stillImageOutput != nil) {
+                captureConnection = [self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
+                if ([captureConnection isVideoOrientationSupported]) {
+                        [captureConnection setVideoOrientation:orientation];
+                }
         }
-    }
-    if (self.dataOutput != nil) {
-        captureConnection = [self.dataOutput connectionWithMediaType:AVMediaTypeVideo];
-        if ([captureConnection isVideoOrientationSupported]) {
-            [captureConnection setVideoOrientation:orientation];
+        if (self.dataOutput != nil) {
+                captureConnection = [self.dataOutput connectionWithMediaType:AVMediaTypeVideo];
+                if ([captureConnection isVideoOrientationSupported]) {
+                        [captureConnection setVideoOrientation:orientation];
+                }
         }
-    }
 }
 - (void) switchCamera
 {
-    if (self.defaultCamera == AVCaptureDevicePositionFront) {
-        self.defaultCamera = AVCaptureDevicePositionBack;
-    } else {
-        self.defaultCamera = AVCaptureDevicePositionFront;
-    }
-
-    dispatch_async([self sessionQueue], ^{
-        NSError *error = nil;
-
-        [self.session beginConfiguration];
-
-        if (self.videoDeviceInput != nil) {
-            [self.session removeInput:[self videoDeviceInput]];
-            [self setVideoDeviceInput:nil];
+        if (self.defaultCamera == AVCaptureDevicePositionFront) {
+                self.defaultCamera = AVCaptureDevicePositionBack;
+        } else {
+                self.defaultCamera = AVCaptureDevicePositionFront;
         }
 
-        AVCaptureDevice *videoDevice = [CameraSessionManager deviceWithMediaType:AVMediaTypeVideo preferringPosition:self.defaultCamera];
+        dispatch_async([self sessionQueue], ^{
+                NSError *error = nil;
 
-        if ([videoDevice hasFlash] && [videoDevice isFlashModeSupported:AVCaptureFlashModeAuto]) {
-            if ([videoDevice lockForConfiguration:&error]) {
-                [videoDevice setFlashMode:AVCaptureFlashModeAuto];
-                [videoDevice unlockForConfiguration];
-            } else {
-                NSLog(@"%@", error);
-            }
-        }
+                [self.session beginConfiguration];
 
-        AVCaptureDeviceInput *videoDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:videoDevice error:&error];
+                if (self.videoDeviceInput != nil) {
+                        [self.session removeInput:[self videoDeviceInput]];
+                        [self setVideoDeviceInput:nil];
+                }
 
-        if (error) {
-            NSLog(@"%@", error);
-        }
+                AVCaptureDevice *videoDevice = [CameraSessionManager deviceWithMediaType:AVMediaTypeVideo preferringPosition:self.defaultCamera];
 
-        if ([self.session canAddInput:videoDeviceInput]) {
-            [self.session addInput:videoDeviceInput];
-            [self setVideoDeviceInput:videoDeviceInput];
-        }
-        
-        [self updateOrientation:[self getCurrentOrientation]];
-        [self.session commitConfiguration];
-    });
+                if ([videoDevice hasFlash] && [videoDevice isFlashModeSupported:AVCaptureFlashModeAuto]) {
+                        if ([videoDevice lockForConfiguration:&error]) {
+                                [videoDevice setFlashMode:AVCaptureFlashModeAuto];
+                                [videoDevice unlockForConfiguration];
+                        } else {
+                                NSLog(@"%@", error);
+                        }
+                }
+
+                AVCaptureDeviceInput *videoDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:videoDevice error:&error];
+
+                if (error) {
+                        NSLog(@"%@", error);
+                }
+
+                if ([self.session canAddInput:videoDeviceInput]) {
+                        [self.session addInput:videoDeviceInput];
+                        [self setVideoDeviceInput:videoDeviceInput];
+                }
+
+                [self updateOrientation:[self getCurrentOrientation]];
+                [self.session commitConfiguration];
+        });
 }
 
 - (void)checkDeviceAuthorizationStatus
 {
-    NSString *mediaType = AVMediaTypeVideo;
+        NSString *mediaType = AVMediaTypeVideo;
 
-    [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
-        if (!granted) {
-            //Not granted access to mediaType
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [[[UIAlertView alloc] initWithTitle:@"Error"
-                                            message:@"Camera permission not found. Please, check your privacy settings."
-                                           delegate:self
+        [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
+                 if (!granted) {
+                         //Not granted access to mediaType
+                         dispatch_async(dispatch_get_main_queue(), ^{
+                                [[[UIAlertView alloc] initWithTitle:@"Error"
+                                  message:@"Camera permission not found. Please, check your privacy settings."
+                                  delegate:self
                                   cancelButtonTitle:@"OK"
                                   otherButtonTitles:nil] show];
-            });
-        }
-    }];
+                        });
+                 }
+         }];
 }
 
 + (AVCaptureDevice *) deviceWithMediaType:(NSString *)mediaType preferringPosition:(AVCaptureDevicePosition)position
 {
-    NSArray *devices = [AVCaptureDevice devicesWithMediaType:mediaType];
-    AVCaptureDevice *captureDevice = [devices firstObject];
+        NSArray *devices = [AVCaptureDevice devicesWithMediaType:mediaType];
+        AVCaptureDevice *captureDevice = [devices firstObject];
 
-    for (AVCaptureDevice *device in devices) {
-        if ([device position] == position) {
-            captureDevice = device;
-            break;
+        for (AVCaptureDevice *device in devices) {
+                if ([device position] == position) {
+                        captureDevice = device;
+                        break;
+                }
         }
-    }
 
-    return captureDevice;
+        return captureDevice;
 }
 
 @end

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -1,33 +1,31 @@
-
 var argscheck = require('cordova/argscheck'),
-	utils = require('cordova/utils'),
-	exec = require('cordova/exec');
+  utils = require('cordova/utils'),
+  exec = require('cordova/exec');
 
 var PLUGIN_NAME = "CameraPreview";
 
-var CameraPreview = function() {
-};
+var CameraPreview = function() {};
 
 CameraPreview.setOnPictureTakenHandler = function(onPictureTaken) {
-	exec(onPictureTaken, onPictureTaken, PLUGIN_NAME, "setOnPictureTakenHandler", []);
+  exec(onPictureTaken, onPictureTaken, PLUGIN_NAME, "setOnPictureTakenHandler", []);
 };
 
 //@param rect {x: 0, y: 0, width: 100, height:100}
 //@param defaultCamera "front" | "back"
 CameraPreview.startCamera = function(rect, defaultCamera, tapEnabled, dragEnabled, toBack, alpha) {
-	if (typeof(alpha) === 'undefined') alpha = 1;
-	exec(null, null, PLUGIN_NAME, "startCamera", [rect.x, rect.y, rect.width, rect.height, defaultCamera, !!tapEnabled, !!dragEnabled, !!toBack, alpha]);
+  if (typeof(alpha) === 'undefined') alpha = 1;
+  exec(null, null, PLUGIN_NAME, "startCamera", [rect.x, rect.y, rect.width, rect.height, defaultCamera, !!tapEnabled, !!dragEnabled, !!toBack, alpha]);
 };
 CameraPreview.stopCamera = function() {
-	exec(null, null, PLUGIN_NAME, "stopCamera", []);
+  exec(null, null, PLUGIN_NAME, "stopCamera", []);
 };
 //@param size {maxWidth: 100, maxHeight:100}
 CameraPreview.takePicture = function(size) {
-	var params = [0, 0];
-	if(size){
-		params = [size.maxWidth, size.maxHeight];
-	}
-	exec(null, null, PLUGIN_NAME, "takePicture", params);
+  var params = [0, 0];
+  if (size) {
+    params = [size.maxWidth, size.maxHeight];
+  }
+  exec(null, null, PLUGIN_NAME, "takePicture", params);
 };
 
 CameraPreview.setColorEffect = function(effect) {
@@ -35,19 +33,19 @@ CameraPreview.setColorEffect = function(effect) {
 };
 
 CameraPreview.switchCamera = function() {
-	exec(null, null, PLUGIN_NAME, "switchCamera", []);
+  exec(null, null, PLUGIN_NAME, "switchCamera", []);
 };
 
 CameraPreview.hide = function() {
-	exec(null, null, PLUGIN_NAME, "hideCamera", []);
+  exec(null, null, PLUGIN_NAME, "hideCamera", []);
 };
 
 CameraPreview.show = function() {
-	exec(null, null, PLUGIN_NAME, "showCamera", []);
+  exec(null, null, PLUGIN_NAME, "showCamera", []);
 };
 
 CameraPreview.disable = function(disable) {
-	exec(null, null, PLUGIN_NAME, "disable", [disable]);
+  exec(null, null, PLUGIN_NAME, "disable", [disable]);
 };
 
 module.exports = CameraPreview;

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -14,8 +14,9 @@ CameraPreview.setOnPictureTakenHandler = function(onPictureTaken) {
 
 //@param rect {x: 0, y: 0, width: 100, height:100}
 //@param defaultCamera "front" | "back"
-CameraPreview.startCamera = function(rect, defaultCamera, tapEnabled, dragEnabled, toBack) {
-	exec(null, null, PLUGIN_NAME, "startCamera", [rect.x, rect.y, rect.width, rect.height, defaultCamera, !!tapEnabled, !!dragEnabled, !!toBack]);
+CameraPreview.startCamera = function(rect, defaultCamera, tapEnabled, dragEnabled, toBack, alpha) {
+	if (typeof(alpha) === 'undefined') alpha = 1;
+	exec(null, null, PLUGIN_NAME, "startCamera", [rect.x, rect.y, rect.width, rect.height, defaultCamera, !!tapEnabled, !!dragEnabled, !!toBack, alpha]);
 };
 CameraPreview.stopCamera = function() {
 	exec(null, null, PLUGIN_NAME, "stopCamera", []);


### PR DESCRIPTION
I needed this feature because the toBack option didn't fit my use case.

By default, the alpha is set to 1 if not specified and the image is displayed normally.
If alpha is set, the camera preview is displayed with transparency.

Before merge this PR, I need someone to test that it works on Android because I don't have any Android device..
I really like to improve this if you have a better way to do it.

Finally, sorry for the beautifying commited with those changes, it has nothing to do with the feature. I can change the PR if you prefer.
