### PR TITLE
Fixing Android onResume issue

### DIFF
--- a/src/android/com/mbppower/CameraActivity.java
+++ b/src/android/com/mbppower/CameraActivity.java
@@ -218,7 +218,13 @@ public class CameraActivity extends Fragment {
         }
 
         cameraCurrentlyLocked = defaultCameraId;
-        mPreview.setCamera(mCamera, cameraCurrentlyLocked);
+        
+        if(mPreview.mPreviewSize == null){
+		mPreview.setCamera(mCamera, cameraCurrentlyLocked);
+	} else {
+		mPreview.switchCamera(mCamera);
+		mCamera.startPreview();
+	}
 
 	    Log.d(TAG, "cameraCurrentlyLocked:" + cameraCurrentlyLocked);
 


### PR DESCRIPTION
On Android, the camera isn't properly restarted when app is paused and resumed.